### PR TITLE
config: Support host ip config with redis

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -111,7 +111,7 @@ class Config(object):
         config.SQLALCHEMY_DATABASE_URI = config.SQL_DATABASE_URI
 
         if config.REDIS_URI:
-            URI_RE = r'redis://(?::(?P<password>.*?)@)?(?P<host>[\w^:\-]+?)(?::(?P<port>\d+))'
+            URI_RE = r'redis://(?::(?P<password>.*?)@)?(?P<host>[\w\d\.^:\-]+?)(?::(?P<port>\d+))'
             password, host, port = re.match(URI_RE, config.REDIS_URI).groups()
             config.CACHE_DEFAULT_BACKEND = "dogpile.cache.redis"
             config.CACHE_ARGUEMENTS = {


### PR DESCRIPTION
Currently only unicode string word supported, add digit
and dot as user might want specify host ip for redis also.

Signed-off-by: Wayne Sun <gsun@redhat.com>