### PR TITLE
entity: Fix query with uuid

### DIFF
--- a/metadash/models/base/entity.py
+++ b/metadash/models/base/entity.py
@@ -87,7 +87,7 @@ class EntityModel(_Jsonable, MetadashEntity, metaclass=RichMixinMeta):
 
     @classmethod
     def from_uuid(cls, uuid):
-        entity = cls.query.filter(uuid == uuid).first()
+        entity = cls.query.filter(cls.uuid == uuid).one()
         return entity
 
     @hybridmethod


### PR DESCRIPTION
The query filter with uuid is not valid as entity name
missing, current function will return first one from all
results.

Also replace first() with one() as the uuid should be
one and only.

Signed-off-by: Wayne Sun <gsun@redhat.com>