### PR TITLE
exceptions: RuntimeError don't have message attribute

### DIFF
--- a/metadash/exceptions/__init__.py
+++ b/metadash/exceptions/__init__.py
@@ -98,7 +98,7 @@ class RemoteAuthError(MetadashAPIError):
                 utils.kinit()
             except RuntimeError as error:
                 response = jsonify({
-                    'message': 'Kerberos init failed with "{}", caused by "{}"'.format(error, error.message),
+                    'message': 'Kerberos init failed with "{}"'.format(error),
                 })
             except Exception as error:
                 response = jsonify({


### PR DESCRIPTION
RuntimeError don't have the message attribute, so can't be
used to format error message.

Signed-off-by: Wayne Sun <gsun@redhat.com>