### PR TITLE
Change gunicorn worker timeout to 5 minutes to suppress "[CRITICAL] W…

### DIFF
--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -2,3 +2,4 @@ import multiprocessing
 
 bind = '0.0.0.0:8080'
 multiprocessing.cpu_count() * 2 + 1
+timeout = 300


### PR DESCRIPTION
…ORKER TIMEOUT"