### PR TITLE
config: Keep the database table name

### DIFF
--- a/metadash/config/config.py
+++ b/metadash/config/config.py
@@ -10,6 +10,7 @@ basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../metadash")
 
 
 class ConfigItemModel(db.Model):
+    __tablename__ = '__metadash_config'
     key = db.Column(db.Text(), primary_key=True, nullable=False)
     value = db.Column(db.Text())
 


### PR DESCRIPTION
The database table name changed after modle name update,
better to keep the original table name.

Signed-off-by: Wayne Sun <gsun@redhat.com>