### PR TITLE
Add vue-axios in replacement of vue-resource

### DIFF
--- a/metadash/src/main.js
+++ b/metadash/src/main.js
@@ -1,6 +1,8 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'
+import axios from 'axios'
+import VueAxios from 'vue-axios'
 import Vuetify from 'vuetify'
 
 // CSS
@@ -19,6 +21,7 @@ import router from '@/router'
 import { Plugins } from '@/plugin'
 import MetadashAPI from '@/libs/metadash-api'
 
+Vue.use(VueAxios, axios)
 Vue.use(Vuetify)
 Vue.use(MetadashAPI)
 Vue.config.productionTip = false

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "semver": "^5.3.0",
     "url-loader": "^0.5.7",
     "vue": "^2.4.2",
+    "vue-axios": "^2.1.4",
     "vue-loader": "^11.3.4",
     "vue-router": "^2.2.0",
     "vue-spinner": "^1.0.2",


### PR DESCRIPTION
`vue-axios` provides prototype binding for `this.$http` and `this.http` which helps the migration of existing plugins.