### PR TITLE
Revert "Fix runtime errors since config has been moved to settings"

### DIFF
--- a/metadash/auth/ldap.py
+++ b/metadash/auth/ldap.py
@@ -5,11 +5,11 @@ from ldap3 import Server, Connection, ALL
 from .base import User, AuthBase, AuthError
 from .. import db
 from ..models import get_or_create
-from metadash import app
+from ..config import Config
 
 
 def get_ldap_server():
-    return Server(app.config['LDAP_SERVER'], get_info=ALL)
+    return Server(Config.get('LDAP_SERVER'), get_info=ALL)
 
 
 class LDAPAuth(AuthBase):

--- a/metadash/settings.py
+++ b/metadash/settings.py
@@ -33,10 +33,6 @@ class AppSettings(object):
     TESTING = False
     SECRET_KEY = ''  # Replace with some random string please
     DEFAULT_AUTH_BACKEND = 'local'
-    LDAP_SERVER = ''
-    KERBEROS_KEYTAB_FILE = ''
-    KERBEROS_PRINCIPLE = ''
-
 
     # SQL Database URI format: "${DATABASE_ENGINE}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_SERVICE}/${DATABASE_NAME}"
     # or (without authentication): "${DATABASE_ENGINE}://${DATABASE_SERVICE}/${DATABASE_NAME}"

--- a/metadash/utils/khelper.py
+++ b/metadash/utils/khelper.py
@@ -2,7 +2,7 @@
 Kerberos helper
 """
 import os
-from metadash import app
+import metadash
 
 
 # TODO: provide User.try_login
@@ -11,7 +11,7 @@ def kinit(username=None, password=None):
     This assumes all plugin requires the same keytab, and the same global session.
     Which is not always true, but useful for some certain plugins.
     """
-    ktab = app.config['KERBEROS_KEYTAB_FILE']
-    kprinciple = app.config['KERBEROS_PRINCIPLE']
+    ktab = metadash.setting.get("KERBEROS_KEYTAB_FILE")
+    kprinciple = metadash.setting.get("KERBEROS_PRINCIPLE")
     if os.system("kinit -k -t {} {}".format(ktab, kprinciple)):
         raise RuntimeError("Kerberos Authentication Failed")


### PR DESCRIPTION
These configuration need to be read and set from metadash.settings but not from environment variables.
This reverts commit e1c3e97cd2ab75ba28376062fe942fab199cedc0.