### PR TITLE
Fix create_user command in md-manager and model issue

### DIFF
--- a/bin/md-manager
+++ b/bin/md-manager
@@ -151,7 +151,7 @@ if __name__ == '__main__':
         return len(result.errors + result.failures)
 
     @manager.command
-    @manager.option('-n', '--name', dest='name')
+    @manager.option('-n', '--username', dest='username')
     @manager.option('-p', '--password', dest='password')
     @manager.option('-r', '--role', dest='role')
     def create_user(username=None, password=None, role="admin"):

--- a/metadash/auth/local.py
+++ b/metadash/auth/local.py
@@ -14,7 +14,7 @@ class LocalUser(db.Model):
     PASSWORD_RE = re.compile(r"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$")
 
     uuid = db.Column(db.ForeignKey(User.uuid), primary_key=True)
-    password = db.Column(db.String(64), nullable=False)
+    password = db.Column(db.String(128), nullable=False)
 
     def __init__(self, uuid, password):
         self.uuid = uuid


### PR DESCRIPTION
When creating a new user from commandline, md-manager refuses to execute the command and tells "too much arguments". Also SQL will tell "value too long for type character varying(64)".

This commit fixes the two problems and make create_user command actually usable.