### PR TITLE
Use ${PREFIX}_DEVELOPMENT_FORCE_CELERY to force task wrapper to retur…

### DIFF
--- a/metadash/settings.py
+++ b/metadash/settings.py
@@ -31,6 +31,7 @@ class AppSettings(object):
     DEBUG = False
     SECURITY = True
     DEVELOPMENT = False
+    DEVELOPMENT_FORCE_CELERY = False
     TESTING = False
     SECRET_KEY = ''  # Replace with some random string please
     DEFAULT_AUTH_BACKEND = 'local'

--- a/metadash/worker/task.py
+++ b/metadash/worker/task.py
@@ -5,6 +5,7 @@ import logging
 
 from celery import current_task
 from .celery import celery
+from metadash import settings
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,8 @@ def task(*args, **kwargs):
             cron.append((periodic, task))
         return task
 
-    if celery:
+    if celery or \
+            (settings.DEVELOPMENT and settings.DEVELOPMENT_FORCE_CELERY):
         return task_wrapper
     else:
         return dumb_wrapper


### PR DESCRIPTION
…n a celery worker

With no celery worker deployed, Metadash will return a dumb task that simulates celery API but execute the task within main thread. This helps sometimes, for example when development locally. However, when huge tasks are queued and executed, Metadash will timeout without a worker. This switch enforces the tasks to be dispatched to a worker and ensures the main thread does not timeout.